### PR TITLE
Dynamic response transformers.

### DIFF
--- a/src/Container/Action/LoadFactory.php
+++ b/src/Container/Action/LoadFactory.php
@@ -16,11 +16,21 @@ use Interop\Container\ContainerInterface;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Api\Action\Load;
+use Prooph\EventStore\Http\Api\Transformer\JsonTransformer;
 
 final class LoadFactory
 {
     public function __invoke(ContainerInterface $container): Load
     {
-        return new Load($container->get(EventStore::class), $container->get(MessageConverter::class));
+        $actionHandler = new Load($container->get(EventStore::class), $container->get(MessageConverter::class));
+
+        $actionHandler->addTransformer(
+            new JsonTransformer(),
+            'application/vnd.eventstore.atom+json',
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
     }
 }

--- a/src/Transformer/JsonTransformer.php
+++ b/src/Transformer/JsonTransformer.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-api.
+ * (c) 2016-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Api\Transformer;
+
+use Psr\Http\Message\ResponseInterface;
+use Zend\Diactoros\Response\JsonResponse;
+
+final class JsonTransformer implements Transformer
+{
+    /**
+     * @param array $result
+     * @return ResponseInterface
+     */
+    public function stream(array $result) : ResponseInterface
+    {
+        return new JsonResponse($result);
+    }
+
+    /**
+     * @param string $message
+     * @param int $code
+     * @return ResponseInterface
+     */
+    public function error(string $message, int $code) : ResponseInterface
+    {
+        return new JsonResponse($message, $code);
+    }
+}

--- a/src/Transformer/Transformer.php
+++ b/src/Transformer/Transformer.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-api.
+ * (c) 2016-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Api\Transformer;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface Transformer
+{
+    /**
+     * @param array $result
+     * @return ResponseInterface
+     */
+    public function stream(array $result) : ResponseInterface;
+
+    /**
+     * @param string $message
+     * @param int $code
+     * @return ResponseInterface
+     */
+    public function error(string $message, int $code) : ResponseInterface;
+}

--- a/tests/Action/LoadTest.php
+++ b/tests/Action/LoadTest.php
@@ -14,8 +14,10 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Api\Action\Load;
+use Prooph\EventStore\Http\Api\Transformer\JsonTransformer;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Diactoros\Response\JsonResponse;
 
 class LoadTest extends TestCase
@@ -35,6 +37,7 @@ class LoadTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class);
 
         $stream = new Load($eventStore->reveal(), $messageConverter->reveal());
+        $stream->addTransformer(new JsonTransformer(), 'application/vnd.eventstore.atom+json');
 
         $response = $stream->__invoke($request->reveal(), $response->reveal(), function () {
         });
@@ -65,6 +68,7 @@ class LoadTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class);
 
         $stream = new Load($eventStore->reveal(), $messageConverter->reveal());
+        $stream->addTransformer(new JsonTransformer(), 'application/vnd.eventstore.atom+json');
 
         $response = $stream->__invoke($request->reveal(), $response->reveal(), function () {
         });
@@ -72,5 +76,43 @@ class LoadTest extends TestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertEquals(400, $response->getStatusCode());
         $this->assertEmpty(json_decode($response->getBody()->getContents()));
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_use_appropriate_transformer(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageConverter = $this->prophesize(MessageConverter::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('streamname')->willReturn('foo')->shouldBeCalled();
+        $request->getAttribute('start')->willReturn('head')->shouldBeCalled();
+        $request->getAttribute('direction')->willReturn('forward')->shouldBeCalled();
+        $request->getAttribute('count')->willReturn('1')->shouldBeCalled();
+
+        $response = $this->prophesize(ResponseInterface::class);
+
+        $stream = new Load($eventStore->reveal(), $messageConverter->reveal());
+
+        $expectedResponses = [
+            'application/vnd.eventstore.atom+json' => new JsonResponse(['transformer-1']),
+            'application/vnd.eventstore.atom+html' => new HtmlResponse('<event></event>'),
+        ];
+
+        // Add all transformers to Load action.
+        foreach ($expectedResponses as $forAcceptedValue => $expectedResponse) {
+            $stream->addTransformer(new TransformerStub($expectedResponse), $forAcceptedValue);
+        }
+
+        foreach ($expectedResponses as $forAcceptedValue => $expectedResponse) {
+            $request->getHeaderLine('Accept')->willReturn($forAcceptedValue);
+
+            $finalResponse = $stream->__invoke($request->reveal(), $response->reveal(), function () {
+            });
+
+            $this->assertSame($expectedResponse, $finalResponse);
+        }
     }
 }

--- a/tests/Action/TransformerStub.php
+++ b/tests/Action/TransformerStub.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-api.
+ * (c) 2016-2016 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2016 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ProophTest\EventStore\Http\Api\Action;
+
+use Prooph\EventStore\Http\Api\Transformer\Transformer;
+use Psr\Http\Message\ResponseInterface;
+
+final class TransformerStub implements Transformer
+{
+    /**
+     * @var ResponseInterface
+     */
+    private $result;
+
+    /**
+     * @param ResponseInterface $result
+     */
+    public function __construct(ResponseInterface $result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * @param array $result
+     * @return ResponseInterface
+     */
+    public function stream(array $result) : ResponseInterface
+    {
+        return $this->result;
+    }
+
+    /**
+     * @param string $message
+     * @param int $code
+     * @return ResponseInterface
+     */
+    public function error(string $message, int $code) : ResponseInterface
+    {
+        return $this->result;
+    }
+}


### PR DESCRIPTION
**- What I did**

Added concept of transformers so you can dynamically add transformers depending on accept header.

**- How I did it**

Added an map (array) for accept header to corresponding transformers.

I was going to have a transformer factory that is injected into the `Load` action how-ever probably a bit over kill.

So instead the container factory for `Load` action can be created by a consumer of this package. Or maybe we can add it to configuration.

**- How to verify it**

Add multiple transformers, for certain your own custom vendor specification or already implemented responses (JsonTransformer). This will then need to be easily added by using your own container factory for `Load` action. This factory will need to call `addTransformer` with the new transformer and possible accept headers for it.

**- Description for the changelog**

- The `Load` action now requires you add a transformer.