### PR TITLE
Improvement/psr15 compatibility

### DIFF
--- a/composer.json.dist
+++ b/composer.json.dist
@@ -37,7 +37,8 @@
         "zendframework/zend-expressive-helpers": "^4.0",
         "zendframework/zend-servicemanager": "^3.3",
         "zendframework/zend-stdlib": "^3.1",
-        "zfcampus/zf-development-mode": "^3.1"
+        "zfcampus/zf-development-mode": "^3.1",
+        "webimpress/http-middleware-compatibility": "^0.1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/src/Middleware/BaseUrl.php
+++ b/src/Middleware/BaseUrl.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 
 namespace Prooph\EventStore\Http\Api\Middleware;
 
+use Psr\Http\Message\ServerRequestInterface;
 use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Helper\UrlHelper;
 
 use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;

--- a/src/Middleware/BaseUrl.php
+++ b/src/Middleware/BaseUrl.php
@@ -11,10 +11,12 @@ declare(strict_types=1);
 
 namespace Prooph\EventStore\Http\Api\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Helper\UrlHelper;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 final class BaseUrl implements MiddlewareInterface
 {
@@ -39,7 +41,7 @@ final class BaseUrl implements MiddlewareInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, HandlerInterface $handler)
     {
         $uri = $request->getUri();
         $uriPath = $uri->getPath();
@@ -55,6 +57,6 @@ final class BaseUrl implements MiddlewareInterface
             $this->urlHelper->setBasePath($this->baseUrl);
         }
 
-        return $delegate->process($request);
+        return $handler->{HANDLER_METHOD}($request);
     }
 }

--- a/tests/unit/Middleware/BaseUrlTest.php
+++ b/tests/unit/Middleware/BaseUrlTest.php
@@ -12,11 +12,11 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Http\Api\Unit\Middleware;
 
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Http\Api\Middleware\BaseUrl;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use Zend\Diactoros\Response\JsonResponse;
 use Zend\Diactoros\Uri;
 use Zend\Expressive\Helper\UrlHelper;

--- a/tests/unit/Middleware/BaseUrlTest.php
+++ b/tests/unit/Middleware/BaseUrlTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace ProophTest\EventStore\Http\Api\Unit\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Http\Api\Middleware\BaseUrl;
 use Psr\Http\Message\ResponseInterface;
@@ -20,6 +20,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\JsonResponse;
 use Zend\Diactoros\Uri;
 use Zend\Expressive\Helper\UrlHelper;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class BaseUrlTest extends TestCase
 {
@@ -47,11 +49,11 @@ class BaseUrlTest extends TestCase
         $request->getUri()->willReturn($uri->reveal());
         $request->withAttribute(BaseUrl::BASE_URL, '/http-api')->willReturn($modifiedRequest->reveal())->shouldBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($finalRequest)->willReturn(new JsonResponse(''))->shouldBeCalled();
+        $handler = $this->prophesize(HandlerInterface::class);
+        $handler->{HANDLER_METHOD}($finalRequest)->willReturn(new JsonResponse(''))->shouldBeCalled();
 
         $middleware = new BaseUrl('/http-api', $urlHelper->reveal());
-        $response = $middleware->process($request->reveal(), $delegate->reveal());
+        $response = $middleware->process($request->reveal(), $handler->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
     }
@@ -72,11 +74,11 @@ class BaseUrlTest extends TestCase
         $request->getUri()->willReturn($uri->reveal());
         $request->withAttribute(BaseUrl::BASE_URL, '/')->willReturn($modifiedRequest->reveal())->shouldBeCalled();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($modifiedRequest)->willReturn(new JsonResponse(''))->shouldBeCalled();
+        $handler = $this->prophesize(HandlerInterface::class);
+        $handler->{HANDLER_METHOD}($modifiedRequest)->willReturn(new JsonResponse(''))->shouldBeCalled();
 
         $middleware = new BaseUrl('/', $urlHelper->reveal());
-        $response = $middleware->process($request->reveal(), $delegate->reveal());
+        $response = $middleware->process($request->reveal(), $handler->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
     }


### PR DESCRIPTION
https://github.com/prooph/psr7-middleware/issues/27

- [http-interop/http-middleware](https://github.com/http-interop/http-middleware),
  which provides the interfaces that will become PSR-15. In Prooph,
  this is pinned to the ^0.4 series. Now you have to explicitly define an
  http-interop/http-middleware dependency in your `composer.json`, and you can
  use any version which is currently supported by the polyfill package
  [webimpress/http-middleware-compatibility](https://github.com/webimpress/http-middleware-compatibility).
